### PR TITLE
Azure Support

### DIFF
--- a/examples/basic_dns_c2_azure.tf
+++ b/examples/basic_dns_c2_azure.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_version = ">= 0.10.0"
+}
+
+module "resource_group" {
+  source = "./modules/azure/create-resource-group"
+}
+
+module "storage_account" {
+  source               = "./modules/azure/create-storage-account"
+  resource_group_names = "${module.resource_group.resource_group_names}"
+  locations            = "${module.resource_group.locations}"
+}
+
+module "dns_c2" {
+  source                  = "./modules/azure/dns-c2"
+  resource_group_names    = "${module.resource_group.resource_group_names}"
+  locations               = "${module.resource_group.locations}"
+  primary_blob_endpoints  = "${module.storage_account.primary_blob_endpoints}"
+  storage_container_names = "${module.storage_account.storage_container_names}"
+}
+
+module "dns_rdir" {
+  source                  = "./modules/azure/dns-rdir"
+  redirect_to             = "${module.dns_c2.ips}"
+  resource_group_names    = "${module.resource_group.resource_group_names}"
+  locations               = "${module.resource_group.locations}"
+  primary_blob_endpoints  = "${module.storage_account.primary_blob_endpoints}"
+  storage_container_names = "${module.storage_account.storage_container_names}"
+}

--- a/examples/basic_http_c2_azure.tf
+++ b/examples/basic_http_c2_azure.tf
@@ -1,0 +1,48 @@
+terraform {
+  required_version = ">= 0.10.0"
+}
+
+module "resource_group" {
+  source = "./modules/azure/create-resource-group"
+  count  = 2
+}
+
+module "storage_account" {
+  source               = "./modules/azure/create-storage-account"
+  resource_group_names = "${module.resource_group.resource_group_names}"
+  locations            = "${module.resource_group.locations}"
+  count                = 2
+}
+
+module "http_c2" {
+  source                  = "./modules/azure/http-c2"
+  resource_group_names    = "${module.resource_group.resource_group_names}"
+  locations               = "${module.resource_group.locations}"
+  primary_blob_endpoints  = "${module.storage_account.primary_blob_endpoints}"
+  storage_container_names = "${module.storage_account.storage_container_names}"
+
+  // 1 http C2 ha. ha. ha... 2 http C2s ha. ha. ha... 3 http C2s ha. ha. ha...
+  //count = 2
+
+  // Wanna install empire?
+  //install = ["./scripts/empire.sh"]
+
+  // Wanna install metasploit?
+  //install = ["./scripts/metasploit.sh"]
+
+  // Wanna install CS?
+  //install = ["./scripts/cobaltstrike.sh"]
+
+  // I WANT EVERYTHING
+  //install = ["./scripts/empire.sh", "./scripts/metasploit.sh", "./scripts/cobaltstrike.sh"]
+}
+
+module "http_rdir" {
+  source                  = "./modules/azure/http-rdir"
+  redirect_to             = "${module.http_c2.ips}"
+  resource_group_names    = "${module.resource_group.resource_group_names}"
+  locations               = "${module.resource_group.locations}"
+  primary_blob_endpoints  = "${module.storage_account.primary_blob_endpoints}"
+  storage_container_names = "${module.storage_account.storage_container_names}"
+  count                   = 2
+}

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -1,0 +1,2 @@
+# Authenticating to Azure
+Details on authenticating to azure in terraform workflows can be found on the [Terraform Azure Provider page](https://www.terraform.io/docs/providers/azurerm/index.html#creating-credentials) as well as on the [Microsoft Docs pages on Terraform](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/terraform-install-configure)

--- a/modules/azure/create-resource-group/README.md
+++ b/modules/azure/create-resource-group/README.md
@@ -1,0 +1,26 @@
+# create-resource-group
+
+Creates a Resource Group in Azure.
+
+# Example
+
+```hcl
+module "resource_group" {
+  source = "./modules/azure/create-resource-group"
+}
+```
+
+# Arguments
+| Name                      | Required | Value Type | Description
+|---------------------------| -------- | ---------- | -----------
+|`count`                    | No       | Integer    | Number of VMs to launch. Defaults to 1.
+|`resource_group_names`     | No       | List       | Names of the Resource Groups to create VMs under. Defaults to `redbaron`
+|`locations`                | No       | List       | Locations to create VM(s) in. Defaults to `eastus2`. A list of available locations can be found on the [Azure Website](https://azure.microsoft.com/en-us/global-infrastructure/services/).
+
+# Outputs
+
+| Name                      | Value Type | Description
+|---------------------------| ---------- | -----------
+|`resource_group_names`     | List       | List of Resource Group Names
+|`locations`                | List       | List of Locations
+

--- a/modules/azure/create-resource-group/main.tf
+++ b/modules/azure/create-resource-group/main.tf
@@ -1,0 +1,11 @@
+provider "azure" {}
+
+resource "random_id" "rand" {
+  byte_length = 4
+}
+
+resource "azurerm_resource_group" "rg" {
+  count    = "${var.count}"
+  location = "${element(var.locations, count.index)}"
+  name     = "${var.resource_group_name}-${count.index}-${random_id.rand.hex}"
+}

--- a/modules/azure/create-resource-group/outputs.tf
+++ b/modules/azure/create-resource-group/outputs.tf
@@ -1,0 +1,7 @@
+output "resource_group_names" {
+  value = "${azurerm_resource_group.rg.*.name}"
+}
+
+output "locations" {
+  value = "${azurerm_resource_group.rg.*.location}"
+}

--- a/modules/azure/create-resource-group/variables.tf
+++ b/modules/azure/create-resource-group/variables.tf
@@ -1,0 +1,13 @@
+variable "count" {
+  default = 1
+}
+
+variable "resource_group_name" {
+  type    = "string"
+  default = "redbaron"
+}
+
+variable "locations" {
+  type    = "list"
+  default = ["eastus2"]
+}

--- a/modules/azure/create-storage-account/README.md
+++ b/modules/azure/create-storage-account/README.md
@@ -1,0 +1,25 @@
+# create-storage-account
+
+Creates a Storage Account and Storage Container in Azure.
+
+# Example
+
+```hcl
+module "resource_group" {
+  source = "./modules/azure/create-resource-group"
+}
+```
+
+# Arguments
+| Name                      | Required | Value Type | Description
+|---------------------------| -------- | ---------- | -----------
+|`count`                    | No       | Integer    | Number of VMs to launch. Defaults to 1.
+|`resource_group_names`     | Yes      | List       | Names of the Resource Groups to create VMs under.
+|`locations`                | No       | List       | Locations to create VM(s) in. Defaults to `eastus2`. A list of available locations can be found on the [Azure Website](https://azure.microsoft.com/en-us/global-infrastructure/services/).
+
+# Outputs
+
+| Name                      | Value Type | Description
+|---------------------------| ---------- | -----------
+|`primary_blob_endpoints`    | List       | List of primary blob endpoints
+|`storage_container_names`   | List       | List of storage container names

--- a/modules/azure/create-storage-account/main.tf
+++ b/modules/azure/create-storage-account/main.tf
@@ -1,0 +1,25 @@
+resource "random_id" "rand" {
+  keepers = {
+    # Generate a new ID only when a new resource group is defined
+    storage_account = "${var.resource_group_names[count.index]}"
+  }
+
+  byte_length = 6
+}
+
+resource "azurerm_storage_account" "sa" {
+  count                    = "${var.count}"
+  name                     = "redbaron${count.index}${random_id.rand.hex}"
+  resource_group_name      = "${var.resource_group_names[count.index]}"
+  location                 = "${var.locations[count.index]}"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "sc" {
+  count                 = "${var.count}"
+  name                  = "vhds"
+  storage_account_name  = "${element(azurerm_storage_account.sa.*.name, count.index)}"
+  resource_group_name   = "${var.resource_group_names[count.index]}"
+  container_access_type = "private"
+}

--- a/modules/azure/create-storage-account/outputs.tf
+++ b/modules/azure/create-storage-account/outputs.tf
@@ -1,0 +1,7 @@
+output "primary_blob_endpoints" {
+  value = "${azurerm_storage_account.sa.*.primary_blob_endpoint}"
+}
+
+output "storage_container_names" {
+  value = "${azurerm_storage_container.sc.*.name}"
+}

--- a/modules/azure/create-storage-account/variables.tf
+++ b/modules/azure/create-storage-account/variables.tf
@@ -1,0 +1,12 @@
+variable "count" {
+  default = 1
+}
+
+variable "resource_group_names" {
+  type = "list"
+}
+
+variable "locations" {
+  type    = "list"
+  default = ["eastus2"]
+}

--- a/modules/azure/dns-c2/README.md
+++ b/modules/azure/dns-c2/README.md
@@ -1,0 +1,33 @@
+# dns-c2
+
+Creates a DNS C2 server in Azure. SSH keys for each virtual machine will be outputted to the ssh_keys folder.
+
+# Example
+
+```hcl
+module "dns_c2" {
+  source                  = "./modules/azure/dns-c2"
+  resource_group_names    = ["<Resource Group Names>"]
+  primary_blob_endpoints  = ["<Primary Blob Endpoints>"]
+  storage_container_names = ["<Storage Container Names>"]
+}
+```
+
+# Arguments
+
+| Name                      | Required | Value Type | Description
+|---------------------------| -------- | ---------- | -----------
+|`count`                    | No       | Integer    | Number of VMs to launch. Defaults to 1.
+|`resource_group_names`     | Yes      | List       | Names of the Resource Groups to create VMs under
+|`storage_container_names`  | Yes      | List       | Names of the Storage Containers for VM hard drives
+|`primary_blob_endpoints`   | Yes      | List       | Names of the Storage Endpoints for VM hard drives
+|`size`                     | No       | String     | VM size to launch. Defaults to `Standard_D2`.
+|`install`                  | No       | List       | Scripts to run on VM creation. Defaults to "./scripts/core_deps.sh".
+|`locations`                | No       | List       | Locations to create VM(s) in. Defaults to `eastus2`. A list of available locations can be found on the [Azure Website](https://azure.microsoft.com/en-us/global-infrastructure/services/).
+|`username`                 | No       | String     | Name of the user account to create. Defaults to `c2user`.
+
+# Outputs
+
+| Name                      | Value Type | Description
+|---------------------------| ---------- | -----------
+|`ips`                      | List       | IPs of created VMs.

--- a/modules/azure/dns-c2/main.tf
+++ b/modules/azure/dns-c2/main.tf
@@ -1,0 +1,108 @@
+provider "azure" {}
+
+resource "tls_private_key" "ssh" {
+  count     = "${var.count}"
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "azurerm_virtual_network" "vnet" {
+  count               = "${var.count}"
+  name                = "dns-c2-vnet"
+  address_space       = ["10.0.0.0/8"]
+  location            = "${var.locations[count.index]}"
+  resource_group_name = "${var.resource_group_names[count.index]}"
+}
+
+resource "azurerm_subnet" "subnet" {
+  count                = "${var.count}"
+  name                 = "subnet01"
+  resource_group_name  = "${var.resource_group_names[count.index]}"
+  virtual_network_name = "${element(azurerm_virtual_network.vnet.*.name, count.index)}"
+  address_prefix       = "10.1.0.0/24"
+}
+
+resource "azurerm_public_ip" "pip" {
+  count                        = "${var.count}"
+  name                         = "dns-c2-pip-${count.index}"
+  location                     = "${var.locations[count.index]}"
+  resource_group_name          = "${var.resource_group_names[count.index]}"
+  public_ip_address_allocation = "static"
+}
+
+resource "azurerm_network_interface" "nic" {
+  count                     = "${var.count}"
+  name                      = "dns-c2-nic-${count.index}"
+  location                  = "${var.locations[count.index]}"
+  resource_group_name       = "${var.resource_group_names[count.index]}"
+  network_security_group_id = "${element(azurerm_network_security_group.nsg.*.id, count.index)}"
+
+  ip_configuration {
+    name                          = "dns-c2-nic-config"
+    subnet_id                     = "${element(azurerm_subnet.subnet.*.id, count.index)}"
+    private_ip_address_allocation = "dynamic"
+    public_ip_address_id          = "${element(azurerm_public_ip.pip.*.id, count.index )}"
+  }
+}
+
+resource "azurerm_virtual_machine" "dns-c2" {
+  count                 = "${var.count}"
+  name                  = "dns-c2-${count.index}"
+  location              = "${var.locations[count.index]}"
+  resource_group_name   = "${var.resource_group_names[count.index]}"
+  network_interface_ids = ["${element(azurerm_network_interface.nic.*.id, count.index)}"]
+  vm_size               = "${var.size}"
+
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
+
+  # Official Debian images for Azure: https://wiki.debian.org/Cloud/MicrosoftAzure
+  storage_image_reference {
+    publisher = "credativ"
+    offer     = "Debian"
+    sku       = "9"
+    version   = "latest"
+  }
+
+  storage_os_disk {
+    count         = "${var.count}"
+    name          = "dns-c2-${count.index}-os"
+    vhd_uri       = "${var.primary_blob_endpoints[count.index]}${var.storage_container_name[count.index]}/dns-c2-${count.index}-os.vhd"
+    caching       = "ReadWrite"
+    create_option = "FromImage"
+  }
+
+  os_profile {
+    computer_name  = "dns-c2-${count.index}"
+    admin_username = "${var.username}"
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = true
+
+    ssh_keys {
+      path     = "/home/${var.username}/.ssh/authorized_keys"
+      key_data = "${tls_private_key.ssh.*.public_key_openssh[count.index]}"
+    }
+  }
+
+  provisioner "remote-exec" {
+    scripts = "${concat(list("./scripts/core_deps.sh"), var.install)}"
+
+    connection {
+      type        = "ssh"
+      host        = "${element(azurerm_public_ip.pip.*.ip_address, count.index )}"
+      user        = "${var.username}"
+      private_key = "${tls_private_key.ssh.*.private_key_pem[count.index]}"
+    }
+  }
+
+  provisioner "local-exec" {
+    command = "echo \"${tls_private_key.ssh.*.private_key_pem[count.index]}\" > ./ssh_keys/dns_c2_${element(azurerm_public_ip.pip.*.ip_address, count.index )} && echo \"${tls_private_key.ssh.*.public_key_openssh[count.index]}\" > ./ssh_keys/dns_c2_${element(azurerm_public_ip.pip.*.ip_address, count.index )}.pub"
+  }
+
+  provisioner "local-exec" {
+    when    = "destroy"
+    command = "rm ./ssh_keys/dns_c2_${element(azurerm_public_ip.pip.*.ip_address, count.index )}*"
+  }
+}

--- a/modules/azure/dns-c2/network-security-group.tf
+++ b/modules/azure/dns-c2/network-security-group.tf
@@ -1,0 +1,66 @@
+resource "azurerm_network_security_group" "nsg" {
+  count               = "${var.count}"
+  name                = "dns-c2-${count.index}-nsg"
+  location            = "${var.locations[count.index]}"
+  resource_group_name = "${var.resource_group_names[count.index]}"
+
+  security_rule {
+    name                       = "SSH-In"
+    priority                   = 1001
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "DNS-In"
+    priority                   = 1002
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Udp"
+    source_port_range          = "*"
+    destination_port_range     = "53"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "DNS-Out"
+    priority                   = 1003
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Udp"
+    source_port_range          = "*"
+    destination_port_range     = "53"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "HTTP-Out"
+    priority                   = 1004
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "80"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "HTTPS-Out"
+    priority                   = 1005
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+}

--- a/modules/azure/dns-c2/outputs.tf
+++ b/modules/azure/dns-c2/outputs.tf
@@ -1,0 +1,3 @@
+output "ips" {
+  value = ["${azurerm_public_ip.pip.*.ip_address}"]
+}

--- a/modules/azure/dns-c2/variables.tf
+++ b/modules/azure/dns-c2/variables.tf
@@ -1,0 +1,33 @@
+variable "resource_group_names" {
+  type = "list"
+}
+
+variable "primary_blob_endpoints" {
+  type = "list"
+}
+
+variable "storage_container_names" {
+  type = "list"
+}
+
+variable "locations" {
+  type    = "list"
+  default = ["eastus2"]
+}
+
+variable "count" {
+  default = 1
+}
+
+variable "username" {
+  default = "c2user"
+}
+
+variable "size" {
+  default = "Standard_D2"
+}
+
+variable "install" {
+  type    = "list"
+  default = []
+}

--- a/modules/azure/dns-rdir/README.md
+++ b/modules/azure/dns-rdir/README.md
@@ -1,0 +1,35 @@
+# dns-rdir
+
+Creates a DNS Redirect server in Azure. SSH keys for each virtual machine will be outputted to the ssh_keys folder.
+
+# Example
+
+```hcl
+module "dns_rdir" {
+  source                  = "./modules/azure/dns-rdir"
+  redirect_to             = ["<List of IPs to forward traffic to>"]
+  resource_group_names    = ["<Resource Group Names>"]
+  primary_blob_endpoints  = ["<Primary Blob Endpoints>"]
+  storage_container_names = ["<Storage Container Names>"]
+}
+```
+
+# Arguments
+
+| Name                      | Required | Value Type | Description
+|---------------------------| -------- | ---------- | -----------
+|`count`                    | No       | Integer    | Number of VMs to launch. Defaults to 1.
+|`redirect_to`              | Yes      | List       | List of IPs to redirect DNS traffic to.
+|`resource_group_names`     | Yes      | List       | Names of the Resource Groups to create VMs under
+|`storage_container_names`  | Yes      | List       | Names of the Storage Containers for VM hard drives
+|`primary_blob_endpoints`   | Yes      | List       | Names of the Storage Endpoints for VM hard drives
+|`size`                     | No       | String     | VM size to launch. Defaults to `Standard_D2`.
+|`install`                  | No       | List       | Scripts to run on VM creation. Defaults to "./scripts/core_deps.sh".
+|`locations`                | No       | List       | Locations to create VM(s) in. Defaults to `eastus2`. A list of available locations can be found on the [Azure Website](https://azure.microsoft.com/en-us/global-infrastructure/services/).
+|`username`                 | No       | String     | Name of the user account to create. Defaults to `c2user`.
+
+# Outputs
+
+| Name                      | Value Type | Description
+|---------------------------| ---------- | -----------
+|`ips`                      | List       | IPs of created VMs.

--- a/modules/azure/dns-rdir/main.tf
+++ b/modules/azure/dns-rdir/main.tf
@@ -1,0 +1,111 @@
+provider "azure" {}
+
+resource "tls_private_key" "ssh" {
+  count     = "${var.count}"
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "azurerm_virtual_network" "vnet" {
+  count               = "${var.count}"
+  name                = "dns-rdir-vnet"
+  address_space       = ["10.0.0.0/8"]
+  location            = "${var.locations[count.index]}"
+  resource_group_name = "${var.resource_group_names[count.index]}"
+}
+
+resource "azurerm_subnet" "subnet" {
+  count                = "${var.count}"
+  name                 = "subnet01"
+  resource_group_name  = "${var.resource_group_names[count.index]}"
+  virtual_network_name = "${element(azurerm_virtual_network.vnet.*.name, count.index)}"
+  address_prefix       = "10.1.0.0/24"
+}
+
+resource "azurerm_public_ip" "pip" {
+  count                        = "${var.count}"
+  name                         = "dns-rdir-pip-${count.index}"
+  location                     = "${var.locations[count.index]}"
+  resource_group_name          = "${var.resource_group_names[count.index]}"
+  public_ip_address_allocation = "static"
+}
+
+resource "azurerm_network_interface" "nic" {
+  count                     = "${var.count}"
+  name                      = "dns-rdir-nic-${count.index}"
+  location                  = "${var.locations[count.index]}"
+  resource_group_name       = "${var.resource_group_names[count.index]}"
+  network_security_group_id = "${element(azurerm_network_security_group.nsg.*.id, count.index)}"
+
+  ip_configuration {
+    name                          = "dns-rdir-nic-config"
+    subnet_id                     = "${element(azurerm_subnet.subnet.*.id, count.index)}"
+    private_ip_address_allocation = "dynamic"
+    public_ip_address_id          = "${element(azurerm_public_ip.pip.*.id, count.index )}"
+  }
+}
+
+resource "azurerm_virtual_machine" "dns-rdir" {
+  count                 = "${var.count}"
+  name                  = "dns-rdir-${count.index}"
+  location              = "${var.locations[count.index]}"
+  resource_group_name   = "${var.resource_group_names[count.index]}"
+  network_interface_ids = ["${element(azurerm_network_interface.nic.*.id, count.index)}"]
+  vm_size               = "${var.size}"
+
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
+
+  # Official Debian images for Azure: https://wiki.debian.org/Cloud/MicrosoftAzure
+  storage_image_reference {
+    publisher = "credativ"
+    offer     = "Debian"
+    sku       = "9"
+    version   = "latest"
+  }
+
+  storage_os_disk {
+    name          = "dns-rdir-${count.index}-os"
+    vhd_uri       = "${var.primary_blob_endpoints[count.index]}${var.storage_container_names[count.index]}/dns-rdir-${count.index}-os.vhd"
+    caching       = "ReadWrite"
+    create_option = "FromImage"
+  }
+
+  os_profile {
+    computer_name  = "dns-rdir-${count.index}"
+    admin_username = "${var.username}"
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = true
+
+    ssh_keys {
+      path     = "/home/${var.username}/.ssh/authorized_keys"
+      key_data = "${tls_private_key.ssh.*.public_key_openssh[count.index]}"
+    }
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo apt-get update",
+      "sudo apt-get install -y tmux socat",
+      "tmux new -d \"sudo socat udp4-recvfrom:53,reuseaddr,fork udp4-sendto:${element(var.redirect_to, count.index)}\"",
+    ]
+
+    connection {
+      type        = "ssh"
+      host        = "${element(azurerm_public_ip.pip.*.ip_address, count.index )}"
+      user        = "${var.username}"
+      private_key = "${tls_private_key.ssh.*.private_key_pem[count.index]}"
+    }
+  }
+
+  provisioner "local-exec" {
+    command = "echo \"${tls_private_key.ssh.*.private_key_pem[count.index]}\" > ./ssh_keys/dns_rdir_${element(azurerm_public_ip.pip.*.ip_address, count.index )} && echo \"${tls_private_key.ssh.*.public_key_openssh[count.index]}\" > ./ssh_keys/dns_rdir_${element(azurerm_public_ip.pip.*.ip_address, count.index )}.pub"
+  }
+
+  provisioner "local-exec" {
+    when    = "destroy"
+    command = "rm ./ssh_keys/dns_rdir_${element(azurerm_public_ip.pip.*.ip_address, count.index )}*"
+  }
+}

--- a/modules/azure/dns-rdir/network-security-group.tf
+++ b/modules/azure/dns-rdir/network-security-group.tf
@@ -1,0 +1,66 @@
+resource "azurerm_network_security_group" "nsg" {
+  count               = "${var.count}"
+  name                = "dns-rdir-${count.index}-nsg"
+  location            = "${var.locations[count.index]}"
+  resource_group_name = "${var.resource_group_names[count.index]}"
+
+  security_rule {
+    name                       = "SSH-In"
+    priority                   = 1001
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "DNS-In"
+    priority                   = 1002
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Udp"
+    source_port_range          = "*"
+    destination_port_range     = "53"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "DNS-Out"
+    priority                   = 1003
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Udp"
+    source_port_range          = "*"
+    destination_port_range     = "53"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "HTTP-Out"
+    priority                   = 1004
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "80"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "HTTPS-Out"
+    priority                   = 1005
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+}

--- a/modules/azure/dns-rdir/outputs.tf
+++ b/modules/azure/dns-rdir/outputs.tf
@@ -1,0 +1,3 @@
+output "ips" {
+  value = ["${azurerm_public_ip.pip.*.ip_address}"]
+}

--- a/modules/azure/dns-rdir/variables.tf
+++ b/modules/azure/dns-rdir/variables.tf
@@ -1,0 +1,37 @@
+variable "resource_group_names" {
+  type = "list"
+}
+
+variable "primary_blob_endpoints" {
+  type = "list"
+}
+
+variable "storage_container_names" {
+  type = "list"
+}
+
+variable "locations" {
+  type    = "list"
+  default = ["eastus2"]
+}
+
+variable "count" {
+  default = 1
+}
+
+variable "redirect_to" {
+  type = "list"
+}
+
+variable "username" {
+  default = "c2user"
+}
+
+variable "install" {
+  type    = "list"
+  default = []
+}
+
+variable "size" {
+  default = "Standard_D2"
+}

--- a/modules/azure/http-c2/README.md
+++ b/modules/azure/http-c2/README.md
@@ -1,0 +1,33 @@
+# http-c2
+
+Creates an HTTP C2 server in Azure. SSH keys for each virtual machine will be outputted to the ssh_keys folder.
+
+# Example
+
+```hcl
+module "http_c2" {
+  source                  = "./modules/azure/http-c2"
+  resource_group_names    = ["<Resource Group Names>"]
+  primary_blob_endpoints  = ["<Primary Blob Endpoints>"]
+  storage_container_names = ["<Storage Container Names>"]
+}
+```
+
+# Arguments
+
+| Name                      | Required | Value Type | Description
+|---------------------------| -------- | ---------- | -----------
+|`count`                    | No       | Integer    | Number of VMs to launch. Defaults to 1.
+|`resource_group_names`     | Yes      | List       | Names of the Resource Groups to create VMs under
+|`storage_container_names`  | Yes      | List       | Names of the Storage Containers for VM hard drives
+|`primary_blob_endpoints`   | Yes      | List       | Names of the Storage Endpoints for VM hard drives
+|`size`                     | No       | String     | VM size to launch. Defaults to `Standard_D2`.
+|`install`                  | No       | List       | Scripts to run on VM creation. Defaults to "./scripts/core_deps.sh".
+|`locations`                | No       | List       | Locations to create VM(s) in. Defaults to `eastus2`. A list of available locations can be found on the [Azure Website](https://azure.microsoft.com/en-us/global-infrastructure/services/).
+|`username`                 | No       | String     | Name of the user account to create. Defaults to `c2user`.
+
+# Outputs
+
+| Name                      | Value Type | Description
+|---------------------------| ---------- | -----------
+|`ips`                      | List       | IPs of created VMs.

--- a/modules/azure/http-c2/main.tf
+++ b/modules/azure/http-c2/main.tf
@@ -1,0 +1,107 @@
+provider "azure" {}
+
+resource "tls_private_key" "ssh" {
+  count     = "${var.count}"
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "azurerm_virtual_network" "vnet" {
+  count               = "${var.count}"
+  name                = "http-c2-vnet"
+  address_space       = ["10.0.0.0/8"]
+  location            = "${var.locations[count.index]}"
+  resource_group_name = "${var.resource_group_names[count.index]}"
+}
+
+resource "azurerm_subnet" "subnet" {
+  count                = "${var.count}"
+  name                 = "subnet01"
+  resource_group_name  = "${var.resource_group_names[count.index]}"
+  virtual_network_name = "${element(azurerm_virtual_network.vnet.*.name, count.index)}"
+  address_prefix       = "10.1.0.0/24"
+}
+
+resource "azurerm_public_ip" "pip" {
+  count                        = "${var.count}"
+  name                         = "http-c2-pip-${count.index}"
+  location                     = "${var.locations[count.index]}"
+  resource_group_name          = "${var.resource_group_names[count.index]}"
+  public_ip_address_allocation = "static"
+}
+
+resource "azurerm_network_interface" "nic" {
+  count                     = "${var.count}"
+  name                      = "http-c2-nic-${count.index}"
+  location                  = "${var.locations[count.index]}"
+  resource_group_name       = "${var.resource_group_names[count.index]}"
+  network_security_group_id = "${element(azurerm_network_security_group.nsg.*.id, count.index)}"
+
+  ip_configuration {
+    name                          = "http-c2-nic-config"
+    subnet_id                     = "${element(azurerm_subnet.subnet.*.id, count.index)}"
+    private_ip_address_allocation = "dynamic"
+    public_ip_address_id          = "${element(azurerm_public_ip.pip.*.id, count.index )}"
+  }
+}
+
+resource "azurerm_virtual_machine" "http-c2" {
+  count                 = "${var.count}"
+  name                  = "http-c2-${count.index}"
+  location              = "${var.locations[count.index]}"
+  resource_group_name   = "${var.resource_group_names[count.index]}"
+  network_interface_ids = ["${element(azurerm_network_interface.nic.*.id, count.index)}"]
+  vm_size               = "${var.size}"
+
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
+
+  # Official Debian images for Azure: https://wiki.debian.org/Cloud/MicrosoftAzure
+  storage_image_reference {
+    publisher = "credativ"
+    offer     = "Debian"
+    sku       = "9"
+    version   = "latest"
+  }
+
+  storage_os_disk {
+    name          = "http-c2-${count.index}-os"
+    vhd_uri       = "${var.primary_blob_endpoints[count.index]}${var.storage_container_names[count.index]}/http-c2-${count.index}-os.vhd"
+    caching       = "ReadWrite"
+    create_option = "FromImage"
+  }
+
+  os_profile {
+    computer_name  = "http-c2-${count.index}"
+    admin_username = "${var.username}"
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = true
+
+    ssh_keys {
+      path     = "/home/${var.username}/.ssh/authorized_keys"
+      key_data = "${tls_private_key.ssh.*.public_key_openssh[count.index]}"
+    }
+  }
+
+  provisioner "remote-exec" {
+    scripts = "${concat(list("./scripts/core_deps.sh"), var.install)}"
+
+    connection {
+      type        = "ssh"
+      host        = "${element(azurerm_public_ip.pip.*.ip_address, count.index )}"
+      user        = "${var.username}"
+      private_key = "${tls_private_key.ssh.*.private_key_pem[count.index]}"
+    }
+  }
+
+  provisioner "local-exec" {
+    command = "echo \"${tls_private_key.ssh.*.private_key_pem[count.index]}\" > ./ssh_keys/http_c2_${element(azurerm_public_ip.pip.*.ip_address, count.index )} && echo \"${tls_private_key.ssh.*.public_key_openssh[count.index]}\" > ./ssh_keys/http_c2_${element(azurerm_public_ip.pip.*.ip_address, count.index )}.pub"
+  }
+
+  provisioner "local-exec" {
+    when    = "destroy"
+    command = "rm ./ssh_keys/http_c2_${element(azurerm_public_ip.pip.*.ip_address, count.index )}*"
+  }
+}

--- a/modules/azure/http-c2/network_security_group.tf
+++ b/modules/azure/http-c2/network_security_group.tf
@@ -1,0 +1,82 @@
+terraform {
+  required_version = ">= 0.10.0"
+}
+
+resource "azurerm_network_security_group" "nsg" {
+  count               = "${var.count}"
+  name                = "http-c2-${count.index}-nsg"
+  location            = "${var.locations[count.index]}"
+  resource_group_name = "${var.resource_group_names[count.index]}"
+
+  security_rule {
+    name                       = "SSH-In"
+    priority                   = 1001
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "HTTP-In"
+    priority                   = 1002
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "80"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "HTTPS-In"
+    priority                   = 1003
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "DNS-Out"
+    priority                   = 1004
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Udp"
+    source_port_range          = "*"
+    destination_port_range     = "53"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "HTTP-Out"
+    priority                   = 1005
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "80"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "HTTPS-Out"
+    priority                   = 1006
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+}

--- a/modules/azure/http-c2/outputs.tf
+++ b/modules/azure/http-c2/outputs.tf
@@ -1,0 +1,3 @@
+output "ips" {
+  value = ["${azurerm_public_ip.pip.*.ip_address}"]
+}

--- a/modules/azure/http-c2/variables.tf
+++ b/modules/azure/http-c2/variables.tf
@@ -1,0 +1,45 @@
+variable "resource_group_names" {
+  type = "list"
+}
+
+variable "primary_blob_endpoints" {
+  type = "list"
+}
+
+variable "storage_container_names" {
+  type = "list"
+}
+
+variable "locations" {
+  type    = "list"
+  default = ["eastus2"]
+}
+
+variable "count" {
+  default = 1
+}
+
+variable "username" {
+  default = "c2user"
+}
+
+variable "size" {
+  default = "Standard_D2"
+}
+
+variable "install" {
+  type    = "list"
+  default = []
+}
+
+/*
+variable "install" {
+  type = "map"
+  default = {
+    "empire" = "./scripts/install_empire.sh"
+    "metasploit" = "./scripts/install_metasploit.sh"
+    "cobaltstrike" = "./scripts/install_cobalt_strike.sh"
+  }
+}
+*/
+

--- a/modules/azure/http-rdir/README.md
+++ b/modules/azure/http-rdir/README.md
@@ -1,0 +1,35 @@
+# http-rdir
+
+Creates a HTTP Redirect server in Azure. SSH keys for each virtual machine will be outputted to the ssh_keys folder.
+
+# Example
+
+```hcl
+module "http_rdir" {
+  source                  = "./modules/azure/http-rdir"
+  redirect_to             = ["<List of IPs to forward traffic to>"]
+  resource_group_names    = ["<Resource Group Names>"]
+  primary_blob_endpoints  = ["<Primary Blob Endpoints>"]
+  storage_container_names = ["<Storage Container Names>"]
+}
+```
+
+# Arguments
+
+| Name                      | Required | Value Type | Description
+|---------------------------| -------- | ---------- | -----------
+|`count`                    | No       | Integer    | Number of VMs to launch. Defaults to 1.
+|`redirect_to`              | Yes      | List       | List of IPs to redirect HTTP traffic to.
+|`resource_group_names`     | Yes      | List       | Names of the Resource Groups to create VMs under
+|`storage_container_names`  | Yes      | List       | Names of the Storage Containers for VM hard drives
+|`primary_blob_endpoints`   | Yes      | List       | Names of the Storage Endpoints for VM hard drives
+|`size`                     | No       | String     | VM size to launch. Defaults to `Standard_D2`.
+|`install`                  | No       | List       | Scripts to run on VM creation. Defaults to "./scripts/core_deps.sh".
+|`locations`                | No       | List       | Locations to create VM(s) in. Defaults to `eastus2`. A list of available locations can be found on the [Azure Website](https://azure.microsoft.com/en-us/global-infrastructure/services/).
+|`username`                 | No       | String     | Name of the user account to create. Defaults to `c2user`.
+
+# Outputs
+
+| Name                      | Value Type | Description
+|---------------------------| ---------- | -----------
+|`ips`                      | List       | IPs of created VMs.

--- a/modules/azure/http-rdir/main.tf
+++ b/modules/azure/http-rdir/main.tf
@@ -1,0 +1,113 @@
+provider "azure" {}
+
+resource "tls_private_key" "ssh" {
+  count     = "${var.count}"
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "azurerm_virtual_network" "vnet" {
+  count               = "${var.count}"
+  name                = "http-rdir-vnet"
+  address_space       = ["10.0.0.0/8"]
+  location            = "${var.locations[count.index]}"
+  resource_group_name = "${var.resource_group_names[count.index]}"
+}
+
+resource "azurerm_subnet" "subnet" {
+  count                = "${var.count}"
+  name                 = "subnet01"
+  resource_group_name  = "${var.resource_group_names[count.index]}"
+  virtual_network_name = "${element(azurerm_virtual_network.vnet.*.name, count.index)}"
+  address_prefix       = "10.1.0.0/24"
+}
+
+resource "azurerm_public_ip" "pip" {
+  count                        = "${var.count}"
+  name                         = "http-rdir-pip-${count.index}"
+  location                     = "${var.locations[count.index]}"
+  resource_group_name          = "${var.resource_group_names[count.index]}"
+  public_ip_address_allocation = "static"
+}
+
+resource "azurerm_network_interface" "nic" {
+  count                     = "${var.count}"
+  name                      = "http-rdir-nic-${count.index}"
+  location                  = "${var.locations[count.index]}"
+  resource_group_name       = "${var.resource_group_names[count.index]}"
+  network_security_group_id = "${element(azurerm_network_security_group.nsg.*.id, count.index)}"
+
+  ip_configuration {
+    name                          = "http-rdir-nic-config"
+    subnet_id                     = "${element(azurerm_subnet.subnet.*.id, count.index)}"
+    private_ip_address_allocation = "dynamic"
+    public_ip_address_id          = "${element(azurerm_public_ip.pip.*.id, count.index )}"
+  }
+}
+
+resource "azurerm_virtual_machine" "http-rdir" {
+  count                 = "${var.count}"
+  name                  = "http-rdir-${count.index}"
+  location              = "${var.locations[count.index]}"
+  resource_group_name   = "${var.resource_group_names[count.index]}"
+  network_interface_ids = ["${element(azurerm_network_interface.nic.*.id, count.index)}"]
+  vm_size               = "${var.size}"
+
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
+
+  # Official Debian images for Azure: https://wiki.debian.org/Cloud/MicrosoftAzure
+  storage_image_reference {
+    publisher = "credativ"
+    offer     = "Debian"
+    sku       = "9"
+    version   = "latest"
+  }
+
+  storage_os_disk {
+    name          = "http-rdir-${count.index}-os"
+    vhd_uri       = "${var.primary_blob_endpoints[count.index]}${var.storage_container_names[count.index]}/http-rdir-${count.index}-os.vhd"
+    caching       = "ReadWrite"
+    create_option = "FromImage"
+  }
+
+  os_profile {
+    computer_name  = "http-rdir-${count.index}"
+    admin_username = "${var.username}"
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = true
+
+    ssh_keys {
+      path     = "/home/${var.username}/.ssh/authorized_keys"
+      key_data = "${tls_private_key.ssh.*.public_key_openssh[count.index]}"
+    }
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo apt-get update",
+      "sudo apt-get install -y tmux socat apache2",
+      "sudo a2enmod rewrite proxy proxy_http ssl",
+      "sudo systemctl stop apache2",
+      "tmux new -d \"sudo socat TCP4-LISTEN:80,fork TCP4:${element(var.redirect_to, count.index)}:80\" ';' split \"sudo socat TCP4-LISTEN:443,fork TCP4:${element(var.redirect_to, count.index)}:443\"",
+    ]
+
+    connection {
+      type        = "ssh"
+      host        = "${element(azurerm_public_ip.pip.*.ip_address, count.index )}"
+      user        = "${var.username}"
+      private_key = "${tls_private_key.ssh.*.private_key_pem[count.index]}"
+    }
+  }
+
+  provisioner "local-exec" {
+    command = "echo \"${tls_private_key.ssh.*.private_key_pem[count.index]}\" > ./ssh_keys/http_rdir_${element(azurerm_public_ip.pip.*.ip_address, count.index )} && echo \"${tls_private_key.ssh.*.public_key_openssh[count.index]}\" > ./ssh_keys/http_rdir_${element(azurerm_public_ip.pip.*.ip_address, count.index )}.pub"
+  }
+
+  provisioner "local-exec" {
+    when    = "destroy"
+    command = "rm ./ssh_keys/http_rdir_${element(azurerm_public_ip.pip.*.ip_address, count.index )}*"
+  }
+}

--- a/modules/azure/http-rdir/network_security_group.tf
+++ b/modules/azure/http-rdir/network_security_group.tf
@@ -1,0 +1,82 @@
+terraform {
+  required_version = ">= 0.10.0"
+}
+
+resource "azurerm_network_security_group" "nsg" {
+  count               = "${var.count}"
+  name                = "http-rdir-${count.index}-nsg"
+  location            = "${var.locations[count.index]}"
+  resource_group_name = "${var.resource_group_names[count.index]}"
+
+  security_rule {
+    name                       = "SSH-In"
+    priority                   = 1001
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "HTTP-In"
+    priority                   = 1002
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "80"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "HTTPS-In"
+    priority                   = 1003
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "DNS-Out"
+    priority                   = 1004
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Udp"
+    source_port_range          = "*"
+    destination_port_range     = "53"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "HTTP-Out"
+    priority                   = 1005
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "80"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "HTTPS-Out"
+    priority                   = 1006
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+}

--- a/modules/azure/http-rdir/outputs.tf
+++ b/modules/azure/http-rdir/outputs.tf
@@ -1,0 +1,3 @@
+output "ips" {
+  value = ["${azurerm_public_ip.pip.*.ip_address}"]
+}

--- a/modules/azure/http-rdir/variables.tf
+++ b/modules/azure/http-rdir/variables.tf
@@ -1,0 +1,49 @@
+variable "resource_group_names" {
+  type = "list"
+}
+
+variable "primary_blob_endpoints" {
+  type = "list"
+}
+
+variable "storage_container_names" {
+  type = "list"
+}
+
+variable "locations" {
+  type    = "list"
+  default = ["eastus2"]
+}
+
+variable "count" {
+  default = 1
+}
+
+variable "redirect_to" {
+  type = "list"
+}
+
+variable "username" {
+  default = "c2user"
+}
+
+variable "size" {
+  default = "Standard_D2"
+}
+
+variable "install" {
+  type    = "list"
+  default = []
+}
+
+/*
+variable "install" {
+  type = "map"
+  default = {
+    "empire" = "./scripts/install_empire.sh"
+    "metasploit" = "./scripts/install_metasploit.sh"
+    "cobaltstrike" = "./scripts/install_cobalt_strike.sh"
+  }
+}
+*/
+

--- a/modules/azure/phishing-server/README.md
+++ b/modules/azure/phishing-server/README.md
@@ -1,0 +1,32 @@
+# phishing-server
+
+Creates a server in Azure to be used as a phishing server. SSH keys for each virtual machine will be outputted to the ssh_keys folder.
+
+# Example
+
+```hcl
+module "phishing_server" {
+  source                  = "./modules/azure/phishing-server"
+  resource_group_names    = ["<Resource Group Names>"]
+  primary_blob_endpoints  = ["<Primary Blob Endpoints>"]
+  storage_container_names = ["<Storage Container Names>"]
+}
+```
+
+# Arguments
+
+| Name                      | Required | Value Type | Description
+|---------------------------| -------- | ---------- | -----------
+|`count`                    | No       | Integer    | Number of VMs to launch. Defaults to 1.
+|`resource_group_names`     | Yes      | List       | Names of the Resource Groups to create VMs under
+|`storage_container_names`  | Yes      | List       | Names of the Storage Containers for VM hard drives
+|`primary_blob_endpoints`   | Yes      | List       | Names of the Storage Endpoints for VM hard drives
+|`size`                     | No       | String     | VM size to launch. Defaults to `Standard_D2`.
+|`locations`                | No       | List       | Locations to create VM(s) in. Defaults to `eastus2`. A list of available locations can be found on the [Azure Website](https://azure.microsoft.com/en-us/global-infrastructure/services/).
+|`username`                 | No       | String     | Name of the user account to create. Defaults to `c2user`.
+
+# Outputs
+
+| Name                      | Value Type | Description
+|---------------------------| ---------- | -----------
+|`ips`                      | List       | IPs of created VMs.

--- a/modules/azure/phishing-server/main.tf
+++ b/modules/azure/phishing-server/main.tf
@@ -1,0 +1,112 @@
+provider "azure" {}
+
+resource "tls_private_key" "ssh" {
+  count     = "${var.count}"
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "azurerm_virtual_network" "vnet" {
+  count               = "${var.count}"
+  name                = "phishing-server-vnet"
+  address_space       = ["10.0.0.0/8"]
+  location            = "${var.locations[count.index]}"
+  resource_group_name = "${var.resource_group_names[count.index]}"
+}
+
+resource "azurerm_subnet" "subnet" {
+  count                = "${var.count}"
+  name                 = "subnet01"
+  resource_group_name  = "${var.resource_group_names[count.index]}"
+  virtual_network_name = "${element(azurerm_virtual_network.vnet.*.name, count.index)}"
+  address_prefix       = "10.1.0.0/24"
+}
+
+resource "azurerm_public_ip" "pip" {
+  count                        = "${var.count}"
+  name                         = "phishing-server-pip-${count.index}"
+  location                     = "${var.locations[count.index]}"
+  resource_group_name          = "${var.resource_group_names[count.index]}"
+  public_ip_address_allocation = "static"
+}
+
+resource "azurerm_network_interface" "nic" {
+  count                     = "${var.count}"
+  name                      = "phishing-server-nic-${count.index}"
+  location                  = "${var.locations[count.index]}"
+  resource_group_name       = "${var.resource_group_names[count.index]}"
+  network_security_group_id = "${element(azurerm_network_security_group.nsg.*.id, count.index)}"
+
+  ip_configuration {
+    name                          = "phishing-server-nic-config"
+    subnet_id                     = "${element(azurerm_subnet.subnet.*.id, count.index)}"
+    private_ip_address_allocation = "dynamic"
+    public_ip_address_id          = "${element(azurerm_public_ip.pip.*.id, count.index )}"
+  }
+}
+
+resource "azurerm_virtual_machine" "phishing-server" {
+  count                 = "${var.count}"
+  name                  = "phishing-server-${count.index}"
+  location              = "${var.locations[count.index]}"
+  resource_group_name   = "${var.resource_group_names[count.index]}"
+  network_interface_ids = ["${element(azurerm_network_interface.nic.*.id, count.index)}"]
+  vm_size               = "${var.size}"
+
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
+
+  # Official Debian images for Azure: https://wiki.debian.org/Cloud/MicrosoftAzure
+  storage_image_reference {
+    publisher = "credativ"
+    offer     = "Debian"
+    sku       = "9"
+    version   = "latest"
+  }
+
+  storage_os_disk {
+    name          = "phishing-server-${count.index}-os"
+    vhd_uri       = "${var.primary_blob_endpoints[count.index]}${var.storage_container_names[count.index]}/phishing-server-${count.index}-os.vhd"
+    caching       = "ReadWrite"
+    create_option = "FromImage"
+  }
+
+  os_profile {
+    computer_name  = "phishing-server-${count.index}"
+    admin_username = "${var.username}"
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = true
+
+    ssh_keys {
+      path     = "/home/${var.username}/.ssh/authorized_keys"
+      key_data = "${tls_private_key.ssh.*.public_key_openssh[count.index]}"
+    }
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo apt-get update",
+      "sudo apt-get install -y tmux apache2 certbot",
+      "sudo a2enmod ssl",
+      "sudo systemctl stop apache2",
+    ]
+
+    connection {
+      type        = "ssh"
+      host        = "${element(azurerm_public_ip.pip.*.ip_address, count.index )}"
+      user        = "${var.username}"
+      private_key = "${tls_private_key.ssh.*.private_key_pem[count.index]}"
+    }
+  }
+
+  provisioner "local-exec" {
+    command = "echo \"${tls_private_key.ssh.*.private_key_pem[count.index]}\" > ./ssh_keys/phishing_server_${element(azurerm_public_ip.pip.*.ip_address, count.index )} && echo \"${tls_private_key.ssh.*.public_key_openssh[count.index]}\" > ./ssh_keys/phishing_server_${element(azurerm_public_ip.pip.*.ip_address, count.index )}.pub"
+  }
+
+  provisioner "local-exec" {
+    when    = "destroy"
+    command = "rm ./ssh_keys/phishing_server_${element(azurerm_public_ip.pip.*.ip_address, count.index )}*"
+  }
+}

--- a/modules/azure/phishing-server/network_security_group.tf
+++ b/modules/azure/phishing-server/network_security_group.tf
@@ -1,0 +1,82 @@
+terraform {
+  required_version = ">= 0.10.0"
+}
+
+resource "azurerm_network_security_group" "nsg" {
+  count               = "${var.count}"
+  name                = "phishing-server-${count.index}-nsg"
+  location            = "${var.locations[count.index]}"
+  resource_group_name = "${var.resource_group_names[count.index]}"
+
+  security_rule {
+    name                       = "SSH-In"
+    priority                   = 1001
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "HTTP-In"
+    priority                   = 1002
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Udp"
+    source_port_range          = "*"
+    destination_port_range     = "80"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "HTTPS-In"
+    priority                   = 1003
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Udp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "DNS-Out"
+    priority                   = 1004
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Udp"
+    source_port_range          = "*"
+    destination_port_range     = "53"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "HTTP-Out"
+    priority                   = 1005
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "80"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "HTTPS-Out"
+    priority                   = 1006
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+}

--- a/modules/azure/phishing-server/outputs.tf
+++ b/modules/azure/phishing-server/outputs.tf
@@ -1,0 +1,3 @@
+output "ips" {
+  value = ["${azurerm_public_ip.pip.*.ip_address}"]
+}

--- a/modules/azure/phishing-server/variables.tf
+++ b/modules/azure/phishing-server/variables.tf
@@ -1,0 +1,40 @@
+variable "resource_group_names" {
+  type = "list"
+}
+
+variable "primary_blob_endpoints" {
+  type = "list"
+}
+
+variable "storage_container_names" {
+  type = "list"
+}
+
+variable "locations" {
+  type    = "list"
+  default = ["eastus2"]
+}
+
+variable "count" {
+  default = 1
+}
+
+variable "username" {
+  default = "c2user"
+}
+
+variable "size" {
+  default = "Standard_D2"
+}
+
+/*
+variable "install" {
+  type = "map"
+  default = {
+    "empire" = "./scripts/install_empire.sh"
+    "metasploit" = "./scripts/install_metasploit.sh"
+    "cobaltstrike" = "./scripts/install_cobalt_strike.sh"
+  }
+}
+*/
+


### PR DESCRIPTION
This PR adds Azure Support to Red Baron. The following modules are Azure specifc:

* **create-resource-group** - This creates an Azure resource group that will contain everything. If multiple regions are specified during the build, one resource group will be created for each region. Further resources will then be placed in the appropriate resource group based on the region they're being created in.

* **create-storage-account** - This creates a storage account and storage container to be used to store VM hard disks

The remaining modules (dns-c2, dns-rdir, http-c2, etc) should match the functionality of other providers. Please let me know if there are any changes you would like to see before landing this PR. 