### PR TITLE
Updated code for getting the GCP Instance Public IP

### DIFF
--- a/modules/google/dns-c2/main.tf
+++ b/modules/google/dns-c2/main.tf
@@ -61,7 +61,7 @@ resource "google_compute_instance" "dns-c2" {
   }
 
   provisioner "local-exec" {
-    command = "echo \"${tls_private_key.ssh.*.private_key_pem[count.index]}\" > ./ssh_keys/dns_rdir_${self.network_interface.0.access_config.0.assigned_nat_ip } && echo \"${tls_private_key.ssh.*.public_key_openssh[count.index]}\" > ./ssh_keys/dns_rdir_${self.network_interface.0.access_config.0.nat_ip}.pub" 
+    command = "echo \"${tls_private_key.ssh.*.private_key_pem[count.index]}\" > ./ssh_keys/dns_rdir_${self.network_interface.0.access_config.0.nat_ip } && echo \"${tls_private_key.ssh.*.public_key_openssh[count.index]}\" > ./ssh_keys/dns_rdir_${self.network_interface.0.access_config.0.nat_ip}.pub" 
   }
 
   provisioner "local-exec" {

--- a/modules/google/dns-c2/main.tf
+++ b/modules/google/dns-c2/main.tf
@@ -61,11 +61,11 @@ resource "google_compute_instance" "dns-c2" {
   }
 
   provisioner "local-exec" {
-    command = "echo \"${tls_private_key.ssh.*.private_key_pem[count.index]}\" > ./ssh_keys/dns_rdir_${self.network_interface.0.access_config.0.assigned_nat_ip } && echo \"${tls_private_key.ssh.*.public_key_openssh[count.index]}\" > ./ssh_keys/dns_rdir_${self.network_interface.0.access_config.0.assigned_nat_ip}.pub" 
+    command = "echo \"${tls_private_key.ssh.*.private_key_pem[count.index]}\" > ./ssh_keys/dns_rdir_${self.network_interface.0.access_config.0.assigned_nat_ip } && echo \"${tls_private_key.ssh.*.public_key_openssh[count.index]}\" > ./ssh_keys/dns_rdir_${self.network_interface.0.access_config.0.nat_ip}.pub" 
   }
 
   provisioner "local-exec" {
     when = "destroy"
-    command = "rm ./ssh_keys/dns_rdir_${self.network_interface.0.access_config.0.assigned_nat_ip}*"
+    command = "rm ./ssh_keys/dns_rdir_${self.network_interface.0.access_config.0.nat_ip}*"
   }
 }

--- a/modules/google/dns-c2/outputs.tf
+++ b/modules/google/dns-c2/outputs.tf
@@ -1,3 +1,3 @@
 output "ips" {
-  value = ["${google_compute_instance.http-rdir.*.network_interface.0.access_config.0.assigned_nat_ip}"]
+  value = ["${google_compute_instance.http-rdir.*.network_interface.0.access_config.0.nat_ip}"]
 }

--- a/modules/google/dns-rdir/main.tf
+++ b/modules/google/dns-rdir/main.tf
@@ -65,7 +65,7 @@ resource "google_compute_instance" "dns-rdir" {
   }
 
   provisioner "local-exec" {
-    command = "echo \"${tls_private_key.ssh.*.private_key_pem[count.index]}\" > ./ssh_keys/dns_rdir_${self.network_interface.0.access_config.0.nat_ip } && echo \"${tls_private_key.ssh.*.public_key_openssh[count.index]}\" > ./ssh_keys/dns_rdir_${self.network_interface.0.access_config.0.assigned_nat_ip}.pub" 
+    command = "echo \"${tls_private_key.ssh.*.private_key_pem[count.index]}\" > ./ssh_keys/dns_rdir_${self.network_interface.0.access_config.0.nat_ip } && echo \"${tls_private_key.ssh.*.public_key_openssh[count.index]}\" > ./ssh_keys/dns_rdir_${self.network_interface.0.access_config.0.nat_ip}.pub" 
   }
 
   provisioner "local-exec" {

--- a/modules/google/dns-rdir/main.tf
+++ b/modules/google/dns-rdir/main.tf
@@ -65,11 +65,11 @@ resource "google_compute_instance" "dns-rdir" {
   }
 
   provisioner "local-exec" {
-    command = "echo \"${tls_private_key.ssh.*.private_key_pem[count.index]}\" > ./ssh_keys/dns_rdir_${self.network_interface.0.access_config.0.assigned_nat_ip } && echo \"${tls_private_key.ssh.*.public_key_openssh[count.index]}\" > ./ssh_keys/dns_rdir_${self.network_interface.0.access_config.0.assigned_nat_ip}.pub" 
+    command = "echo \"${tls_private_key.ssh.*.private_key_pem[count.index]}\" > ./ssh_keys/dns_rdir_${self.network_interface.0.access_config.0.nat_ip } && echo \"${tls_private_key.ssh.*.public_key_openssh[count.index]}\" > ./ssh_keys/dns_rdir_${self.network_interface.0.access_config.0.assigned_nat_ip}.pub" 
   }
 
   provisioner "local-exec" {
     when = "destroy"
-    command = "rm ./ssh_keys/dns_rdir_${self.network_interface.0.access_config.0.assigned_nat_ip}*"
+    command = "rm ./ssh_keys/dns_rdir_${self.network_interface.0.access_config.0.nat_ip}*"
   }
 }

--- a/modules/google/dns-rdir/outputs.tf
+++ b/modules/google/dns-rdir/outputs.tf
@@ -1,3 +1,3 @@
 output "ips" {
-  value = ["${google_compute_instance.http-rdir.*.network_interface.0.access_config.0.assigned_nat_ip}"]
+  value = ["${google_compute_instance.http-rdir.*.network_interface.0.access_config.0.nat_ip}"]
 }

--- a/modules/google/http-c2/main.tf
+++ b/modules/google/http-c2/main.tf
@@ -61,7 +61,7 @@ resource "google_compute_instance" "http-c2" {
   }
 
   provisioner "local-exec" {
-    command = "echo \"${tls_private_key.ssh.*.private_key_pem[count.index]}\" > ./ssh_keys/http_c2_${self.network_interface.0.access_config.0.assigned_nat_ip} && echo \"${tls_private_key.ssh.*.public_key_openssh[count.index]}\" > ./ssh_keys/http_c2_${self.network_interface.0.access_config.0.nat_ip}.pub" 
+    command = "echo \"${tls_private_key.ssh.*.private_key_pem[count.index]}\" > ./ssh_keys/http_c2_${self.network_interface.0.access_config.0.nat_ip} && echo \"${tls_private_key.ssh.*.public_key_openssh[count.index]}\" > ./ssh_keys/http_c2_${self.network_interface.0.access_config.0.nat_ip}.pub" 
   }
 
   provisioner "local-exec" {

--- a/modules/google/http-c2/main.tf
+++ b/modules/google/http-c2/main.tf
@@ -66,6 +66,6 @@ resource "google_compute_instance" "http-c2" {
 
   provisioner "local-exec" {
     when = "destroy"
-    command = "rm ./ssh_keys/http_c2_${self.network_interface.0.access_config.0.assigned_nat_ip}*"
+    command = "rm ./ssh_keys/http_c2_${self.network_interface.0.access_config.0.nat_ip}*"
   }
 }

--- a/modules/google/http-c2/main.tf
+++ b/modules/google/http-c2/main.tf
@@ -61,7 +61,7 @@ resource "google_compute_instance" "http-c2" {
   }
 
   provisioner "local-exec" {
-    command = "echo \"${tls_private_key.ssh.*.private_key_pem[count.index]}\" > ./ssh_keys/http_c2_${self.network_interface.0.access_config.0.assigned_nat_ip} && echo \"${tls_private_key.ssh.*.public_key_openssh[count.index]}\" > ./ssh_keys/http_c2_${self.network_interface.0.access_config.0.assigned_nat_ip}.pub" 
+    command = "echo \"${tls_private_key.ssh.*.private_key_pem[count.index]}\" > ./ssh_keys/http_c2_${self.network_interface.0.access_config.0.assigned_nat_ip} && echo \"${tls_private_key.ssh.*.public_key_openssh[count.index]}\" > ./ssh_keys/http_c2_${self.network_interface.0.access_config.0.nat_ip}.pub" 
   }
 
   provisioner "local-exec" {

--- a/modules/google/http-c2/outputs.tf
+++ b/modules/google/http-c2/outputs.tf
@@ -1,3 +1,3 @@
 output "ips" {
-  value = ["${google_compute_instance.http-c2.*.network_interface.0.access_config.0.assigned_nat_ip}"]
+  value = ["${google_compute_instance.http-c2.*.network_interface.0.access_config.0.nat_ip}"]
 }

--- a/modules/google/http-rdir/main.tf
+++ b/modules/google/http-rdir/main.tf
@@ -67,7 +67,7 @@ resource "google_compute_instance" "http-rdir" {
   }
 
   provisioner "local-exec" {
-    command = "echo \"${tls_private_key.ssh.*.private_key_pem[count.index]}\" > ./ssh_keys/http_rdir_${self.network_interface.0.access_config.0.assigned_nat_ip } && echo \"${tls_private_key.ssh.*.public_key_openssh[count.index]}\" > ./ssh_keys/http_rdir_${self.network_interface.0.access_config.0.nat_ip}.pub" 
+    command = "echo \"${tls_private_key.ssh.*.private_key_pem[count.index]}\" > ./ssh_keys/http_rdir_${self.network_interface.0.access_config.0.nat_ip } && echo \"${tls_private_key.ssh.*.public_key_openssh[count.index]}\" > ./ssh_keys/http_rdir_${self.network_interface.0.access_config.0.nat_ip}.pub" 
   }
 
   provisioner "local-exec" {

--- a/modules/google/http-rdir/main.tf
+++ b/modules/google/http-rdir/main.tf
@@ -72,6 +72,6 @@ resource "google_compute_instance" "http-rdir" {
 
   provisioner "local-exec" {
     when = "destroy"
-    command = "rm ./ssh_keys/http_rdir_${self.network_interface.0.access_config.0.assigned_nat_ip}*"
+    command = "rm ./ssh_keys/http_rdir_${self.network_interface.0.access_config.0.nat_ip}*"
   }
 }

--- a/modules/google/http-rdir/main.tf
+++ b/modules/google/http-rdir/main.tf
@@ -67,7 +67,7 @@ resource "google_compute_instance" "http-rdir" {
   }
 
   provisioner "local-exec" {
-    command = "echo \"${tls_private_key.ssh.*.private_key_pem[count.index]}\" > ./ssh_keys/http_rdir_${self.network_interface.0.access_config.0.assigned_nat_ip } && echo \"${tls_private_key.ssh.*.public_key_openssh[count.index]}\" > ./ssh_keys/http_rdir_${self.network_interface.0.access_config.0.assigned_nat_ip}.pub" 
+    command = "echo \"${tls_private_key.ssh.*.private_key_pem[count.index]}\" > ./ssh_keys/http_rdir_${self.network_interface.0.access_config.0.assigned_nat_ip } && echo \"${tls_private_key.ssh.*.public_key_openssh[count.index]}\" > ./ssh_keys/http_rdir_${self.network_interface.0.access_config.0.nat_ip}.pub" 
   }
 
   provisioner "local-exec" {

--- a/modules/google/http-rdir/outputs.tf
+++ b/modules/google/http-rdir/outputs.tf
@@ -1,3 +1,3 @@
 output "ips" {
-  value = ["${google_compute_instance.http-rdir.*.network_interface.0.access_config.0.assigned_nat_ip}"]
+  value = ["${google_compute_instance.http-rdir.*.network_interface.0.access_config.0.nat_ip}"]
 }

--- a/modules/google/phishing-server/main.tf
+++ b/modules/google/phishing-server/main.tf
@@ -66,7 +66,7 @@ resource "google_compute_instance" "phishing-server" {
   }
 
   provisioner "local-exec" {
-    command = "echo \"${tls_private_key.ssh.*.private_key_pem[count.index]}\" > ./ssh_keys/phishing_server_${self.network_interface.0.access_config.0.assigned_nat_ip } && echo \"${tls_private_key.ssh.*.public_key_openssh[count.index]}\" > ./ssh_keys/phishing_server_${self.network_interface.0.access_config.0.nat_ip}.pub" 
+    command = "echo \"${tls_private_key.ssh.*.private_key_pem[count.index]}\" > ./ssh_keys/phishing_server_${self.network_interface.0.access_config.0.nat_ip } && echo \"${tls_private_key.ssh.*.public_key_openssh[count.index]}\" > ./ssh_keys/phishing_server_${self.network_interface.0.access_config.0.nat_ip}.pub" 
   }
 
   provisioner "local-exec" {

--- a/modules/google/phishing-server/main.tf
+++ b/modules/google/phishing-server/main.tf
@@ -66,11 +66,11 @@ resource "google_compute_instance" "phishing-server" {
   }
 
   provisioner "local-exec" {
-    command = "echo \"${tls_private_key.ssh.*.private_key_pem[count.index]}\" > ./ssh_keys/phishing_server_${self.network_interface.0.access_config.0.assigned_nat_ip } && echo \"${tls_private_key.ssh.*.public_key_openssh[count.index]}\" > ./ssh_keys/phishing_server_${self.network_interface.0.access_config.0.assigned_nat_ip}.pub" 
+    command = "echo \"${tls_private_key.ssh.*.private_key_pem[count.index]}\" > ./ssh_keys/phishing_server_${self.network_interface.0.access_config.0.assigned_nat_ip } && echo \"${tls_private_key.ssh.*.public_key_openssh[count.index]}\" > ./ssh_keys/phishing_server_${self.network_interface.0.access_config.0.nat_ip}.pub" 
   }
 
   provisioner "local-exec" {
     when = "destroy"
-    command = "rm ./ssh_keys/phishing_server_${self.network_interface.0.access_config.0.assigned_nat_ip}*"
+    command = "rm ./ssh_keys/phishing_server_${self.network_interface.0.access_config.0.nat_ip}*"
   }
 }

--- a/modules/google/phishing-server/outputs.tf
+++ b/modules/google/phishing-server/outputs.tf
@@ -1,3 +1,3 @@
 output "ips" {
-  value = ["${google_compute_instance.http-rdir.*.network_interface.0.access_config.0.assigned_nat_ip}"]
+  value = ["${google_compute_instance.http-rdir.*.network_interface.0.access_config.0.nat_ip}"]
 }


### PR DESCRIPTION
Updated code for getting the GCP Instance Public IP.  This was causing the remote execution command, such as `socat`  to fail.